### PR TITLE
Replace add-path with environment command

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,12 +4,7 @@ import * as exec from '@actions/exec';
 
 async function add_path(targetdir) {
   try {
-    const filePath = process.env['GITHUB_PATH'] || ''
-    if (filePath) {
-      await exec.exec(`echo "${targetdir}" >> $GITHUB_PATH`);
-    } else {
-      await exec.exec(`echo "PATH=${targetdir}" >> $GITHUB_ENV`);
-    }
+  	process.env['PATH'] = [targetdir, process.env.PATH].join(path.delimiter)
   } catch (error) {
     core.setFailed(error.message);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,18 @@ import * as process from "process";
 import * as core from '@actions/core';
 import * as exec from '@actions/exec';
 
+async function add_path(targetdir) {
+  try {
+    const filePath = process.env['GITHUB_PATH'] || ''
+    if (filePath) {
+      await exec.exec(`echo "${targetdir}" >> $GITHUB_PATH`]);
+    } else {
+      await exec.exec(`echo "PATH=${targetdir}" >> $GITHUB_ENV`);
+    }
+  } catch (error) {
+    core.setFailed(error.message);
+  }
+}
 
 async function install_target(target_base, name, targetdir) {
   try {
@@ -9,7 +21,6 @@ async function install_target(target_base, name, targetdir) {
     const executable = targetdir + '/' + name;
     await exec.exec(`wget -c -nv ${target} -O ${executable}`);
     await exec.exec(`chmod +x ${executable}`);
-    await exec.exec('echo',[`${targetdir}`,'>> $GITHUB_PATH']);
   } catch (error) {
     core.setFailed(error.message);
   }
@@ -48,7 +59,7 @@ async function run() {
         };
       }
     }
-
+    await add_path(targetdir)
   } catch (error) {
     core.setFailed(error.message);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,7 @@ async function install_target(target_base, name, targetdir) {
     const executable = targetdir + '/' + name;
     await exec.exec(`wget -c -nv ${target} -O ${executable}`);
     await exec.exec(`chmod +x ${executable}`);
-    core.addPath(targetdir);
+    await exec.exec('echo',[`${targetdir}`,'>> $GITHUB_PATH']);
   } catch (error) {
     core.setFailed(error.message);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ async function add_path(targetdir) {
   try {
     const filePath = process.env['GITHUB_PATH'] || ''
     if (filePath) {
-      await exec.exec(`echo "${targetdir}" >> $GITHUB_PATH`]);
+      await exec.exec(`echo "${targetdir}" >> $GITHUB_PATH`);
     } else {
       await exec.exec(`echo "PATH=${targetdir}" >> $GITHUB_ENV`);
     }


### PR DESCRIPTION
Drop deprecated add-path and use environment command.

cf. https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

Signed-off-by: Hiroshi Miura <miurahr@linux.com>