### PR TITLE
Add gstreamer plugin

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -63,6 +63,14 @@ const run = async (): Promise<void> => {
             )
             break
           }
+          case 'gstreamer': {
+            await install_target(
+              'https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gstreamer/master/',
+              'linuxdeploy-plugin-gstreamer.sh',
+              targetdir
+            )
+            break
+          }
         }
       }
     }


### PR DESCRIPTION
The plugin copies GStreamer plugins into an AppDir, and installs an AppRun hook to make GStreamer load these instead of ones on the system.

A plugin is a shell script that needs to be downloaded from the repository.