### PR TITLE
Support arm64 runners

### DIFF
--- a/.github/workflows/test_default.yml
+++ b/.github/workflows/test_default.yml
@@ -8,7 +8,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, ubuntu-22.04-arm]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -21,9 +25,10 @@ jobs:
         run: npm run format-check && npm run lint
       - name: build
         run: npm run build && npm run package
-      - name: Install LinuxDeploy
+      - id: install-linuxdeploy
+        name: Install LinuxDeploy
         uses: ./
       - name: Launch LinuxDeploy
         run: |
-          linuxdeploy-x86_64.AppImage --version
+          ${{ steps.install-linuxdeploy.outputs.linuxdeploy }} --version
         shell: bash

--- a/.github/workflows/test_plugins.yml
+++ b/.github/workflows/test_plugins.yml
@@ -8,7 +8,15 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            plugins: 'qt appimage gtk ncurses gstreamer python conda'
+          - os: ubuntu-22.04-arm
+            plugins: 'qt appimage gtk ncurses gstreamer conda'
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -19,11 +27,12 @@ jobs:
         run: npm install
       - name: build
         run: npm run build && npm run package
-      - name: Install LinuxDeploy
+      - id: install-linuxdeploy
+        name: Install LinuxDeploy
         uses: ./
         with:
-          plugins: qt appimage gtk ncurses gstreamer python conda
+          plugins: ${{ matrix.plugins }}
       - name: List LinuxDeploy plugins
         run: |
-          linuxdeploy-x86_64.AppImage --list-plugins
+          ${{ steps.install-linuxdeploy.outputs.linuxdeploy }} --list-plugins
         shell: bash

--- a/README.md
+++ b/README.md
@@ -8,23 +8,26 @@ You can specify plugins.
 
 ```yml
     - name: Install LinuxDeploy
+      id: install-linuxdeploy
       uses: miurahr/install-linuxdeploy-action@v1
       with:
         plugins: qt appimage
 ```
-You can call the utility like as follows:
+You can call the utility in a run step like as follows:
 
 ```bash
-linuxdeploy-x86_64.AppImage --plugin=qt --output=appimage --create-desktop-file --executable=Apps --appdir appdir --icon-file=Apps.svg
+${{ steps.install-linuxdeploy.outputs.linuxdeploy }} --plugin=qt --output=appimage --create-desktop-file --executable=Apps --appdir appdir --icon-file=Apps.svg
 ```
 
 You can also optionally specify a directory to install, that is added to search PATH.
+You can also optionally request installation of LinuxDeploy and plugins for a specific architecture (allowed values `x64` and `arm64`; defaults to the runner's architecture).
 
 ```yml
     - name: Install LinuxDeploy
       uses: miurahr/install-linuxdeploy-action@v1
       with:
         dir: ${{ github.workspace }}
+        arch: x64
 ```
 
 This action is distributed under the [MIT license](LICENSE).

--- a/action.yml
+++ b/action.yml
@@ -5,10 +5,15 @@ branding:
   icon: 'package'
   color: 'green'
 inputs:
+  arch:
+    description: 'Architecture to install for'
   dir:
     description: 'Directory to install'
   plugins:
     description: 'Plugin modules to install'
+outputs:
+  linuxdeploy:
+    description: 'Path to main linuxdeploy binary'
 runs:
   using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
With ARM desktop systems (Apple Silicon and Snapdragon X) slowly gaining Linux support, and Github now offering access to ARM64 runners to public projects, I think a way to setup the LinuxDeploy and plugins AppImages in a architecture agnostic way within Github Actions will be useful for adoption.

This change downloads the appropriate files based on the current runner architecture - which can be overridden via an input (if perhaps cross-compiling via emulator). Since the file name of AppImages includes the architecture they were built for and therefore variant, the change also includes exposing the full path to the main LinuxDeploy utility as an output of the action. It is backwards compatible, so the existing way keeps working too.

